### PR TITLE
bugfixes and bump version to 1.0.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>uk.ac.ox.micron</groupId>
   <artifactId>SIMcheck</artifactId>
-  <version>0.9.9</version>
+  <version>1.0.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>SIMcheck</name>

--- a/src/main/java/SIMcheck/Raw_IntensityProfiles.java
+++ b/src/main/java/SIMcheck/Raw_IntensityProfiles.java
@@ -26,6 +26,7 @@ import ij.gui.*;
 import ij.IJ;
 
 import java.awt.Color;
+import java.util.Arrays;
 
 /** This plugin plots slice average intensity for each channel of raw SI data
  * to evaluate intensity stability as phase, Z, angle and time are incremented.
@@ -135,7 +136,8 @@ public class Raw_IntensityProfiles implements PlugIn, Executable {
                 Color color = Color.BLACK;  // channels beyond 3rd BLACK 
                 plot.setColor(color);
             }
-            plot.addPoints(pzat_no, avIntensities, 1);
+            float[] channelItens = Arrays.copyOf(avIntensities, pzat);
+            plot.addPoints(pzat_no, channelItens, Plot.LINE);
             
             // TODO: refactor the code below, which has grown very messy!
             
@@ -242,7 +244,7 @@ public class Raw_IntensityProfiles implements PlugIn, Executable {
                     ResultSet.StatOK.NA);
             
         }
-        
+        IJ.log("each color with a different symbol???");
         ImagePlus impResult = plot.getImagePlus();
         I1l.drawPlotTitle(impResult, "Raw data intensity profile (C1=red,"
                 + " C2=green, C3=blue, C4=black)");

--- a/src/main/java/SIMcheck/SIMcheck_.java
+++ b/src/main/java/SIMcheck/SIMcheck_.java
@@ -42,7 +42,7 @@ import java.util.*;
 public final class SIMcheck_ implements PlugIn {
     
     // constants
-    private static final String VERSION = "0.9.9";
+    private static final String VERSION = "1.0.0-SNAPSHOT";
     private static final String none = "[None]";  // no image
     private static final String omx = "OMX (CPZAT)";
 

--- a/src/main/java/SIMcheck/Util_RescaleTo16bit.java
+++ b/src/main/java/SIMcheck/Util_RescaleTo16bit.java
@@ -128,6 +128,7 @@ public class Util_RescaleTo16bit implements PlugIn {
         for (int c = 0; c < imps.length; c++) {
             double minimum = minima[c];
             IJ.run(imps[c], "Min...", "value=" + minimum + " stack");
+            IJ.run(imps[c], "Subtract...", "value=" + minimum + " stack");
         }
         imp.setStack(I1l.mergeChannels(imp.getTitle(), imps).getStack());
     }

--- a/src/main/resources/plugins.config
+++ b/src/main/resources/plugins.config
@@ -1,7 +1,7 @@
 # Name: SIMcheck
 # Author: Graeme Ball
-# Version: 0.9.9
-# Date: May 2015
+# Version: 1.0.0-SNAPSHOT
+# Date: July 2015
 # Requires: ImageJ 
 
 Plugins>SIMcheck>, " Run SIMcheck", SIMcheck.SIMcheck_


### PR DESCRIPTION
- bump version to 1.0.0-SNAPSHOT
- CIP bugfix: did not display all channels on plot
- 16-bit util bugfix: did not subtract manually specified minimum