### PR TITLE
java NullPointerException when running Util_SItoPseudoWidefield in headless mode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,24 @@
       <version>RELEASE</version>
     </dependency>
 
+    <dependency>
+      <groupId>net.imagej</groupId>
+      <artifactId>imagej</artifactId>
+      <version>RELEASE</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.scijava</groupId>
+      <artifactId>scijava-common</artifactId>
+      <version>RELEASE</version>
+    </dependency>
+
+    <dependency>
+      <groupId>net.imagej</groupId>
+      <artifactId>imagej-ops</artifactId>
+      <version>RELEASE</version>
+    </dependency>
+
     <!-- Test dependencies -->
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
I'm writing an ImageJ script to run in headless mode that makes use of SIMcheck (I'm only using the SI to pseudowidefield at the moment but I'm hoping to use it more later) but it fails:

    from ij import IJ
    from loci.plugins import BF
    from SIMcheck import Util_SItoPseudoWidefield
    from SIMcheck import I1l
    
    imp = BF.openImagePlus(fpath)[0]
    
    proj_mode = Util_SItoPseudoWidefield.ProjMode.AVG
    norm_imp = I1l.normalizeImp(imp)
    Util_SItoPseudoWidefield().exec(norm_imp, 5, 3, proj_mode) # throws NullPointerException

The stack:

    java.lang.NullPointerException
	    at ij.plugin.Scaler.showDialog(Scaler.java:207)
	    at ij.plugin.Scaler.run(Scaler.java:42)
	    at ij.IJ.runPlugIn(IJ.java:182)
	    at ij.Executer.runCommand(Executer.java:136)
	    at ij.Executer.run(Executer.java:65)
	    at ij.IJ.run(IJ.java:292)
	    at ij.IJ.run(IJ.java:347)
	    at SIMcheck.Util_SItoPseudoWidefield.exec(Util_SItoPseudoWidefield.java:118)
	    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	    at java.lang.reflect.Method.invoke(Method.java:606)
	    at org.python.core.PyReflectedFunction.__call__(PyReflectedFunction.java:186)
	    at org.python.core.PyObject.__call__(PyObject.java:345)
	    at org.python.core.PyMethod.__call__(PyMethod.java:170)
	    at org.python.pycode._pyx0.main$1(scripts/rawSIM_to_fakeWF.py:67)
	    at org.python.pycode._pyx0.call_function(scripts/rawSIM_to_fakeWF.py)
	    at org.python.core.PyTableCode.call(PyTableCode.java:165)
	    at org.python.core.PyBaseCode.call(PyBaseCode.java:120)
	    at org.python.core.PyFunction.__call__(PyFunction.java:307)
	    at org.python.pycode._pyx0.f$0(scripts/rawSIM_to_fakeWF.py:70)
	    at org.python.pycode._pyx0.call_function(scripts/rawSIM_to_fakeWF.py)
	    at org.python.core.PyTableCode.call(PyTableCode.java:165)
	    at org.python.core.PyCode.call(PyCode.java:18)
	    at org.python.core.Py.runCode(Py.java:1275)
	    at org.python.util.PythonInterpreter.execfile(PythonInterpreter.java:235)
	    at org.python.util.jython.run(jython.java:247)
	    at org.python.util.jython.main(jython.java:129)
	    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
	    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	    at java.lang.reflect.Method.invoke(Method.java:606)
	    at net.imagej.launcher.ClassLauncher.launch(ClassLauncher.java:279)
	    at net.imagej.launcher.ClassLauncher.run(ClassLauncher.java:186)
	    at net.imagej.launcher.ClassLauncher.main(ClassLauncher.java:77)

So I tried to reimplement the whole thing directly calling ij.plugin.scaler (not sure if that solve it anyway) instead of IJ.run (which is what SIMcheck is doing) but then `projectPandA()` (which would be needed) is a private method.